### PR TITLE
Tweaked the demos

### DIFF
--- a/src/Demo.js
+++ b/src/Demo.js
@@ -38,16 +38,34 @@ const Order = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0.5rem;
-  
+  padding: 1rem;
   > ol {
     display: flex;
-    flex-wrap: wrap;
     justify-content: center;
-    padding: 0.5rem 0.5rem;
-    margin: 1rem;
+    margin: 1rem 0;
     background: white;
     border: 1px solid #ccc;
+    width: 100%;
+    @media (max-width: 543px) {
+      flex-wrap: wrap-reverse;
+      * { margin-top: 0; }
+      * + * { margin-bottom: 0.5rem; }
+    }
+    .wayfinder {
+      background: #f7f7f7;
+      align-self: center;
+      line-height: 2rem;
+      font-size: 10px;
+      color: #999;
+      flex: 1;
+      padding: 1rem 0;
+      border: 1px solid #f7f7f7;
+      height: 4rem;
+      @media (min-width: 544px) {
+        &:first-child { margin-right: 0.5rem; }
+        &:last-child { margin-left: 0.5rem; }
+      }
+    }
   }
   width: 100%;
   text-align: center;
@@ -56,7 +74,6 @@ const Order = styled.div`
 const Square = styled.li`
   width: 3rem;
   height: 3rem;
-  margin: 1rem 1rem;
   background: ${props => props.background};
   border: ${props => props.border};
   display: flex;
@@ -64,6 +81,10 @@ const Square = styled.li`
   box-shadow: ${props => props.sc ? '0 0 0 2px white, 0 0 0 3px black' : '0 0 4px 1px #eee' };
   font-size: 0.75rem;
   padding: 0.25rem;
+  margin: 0.5rem;
+  @media (max-width: 543px) {
+    width: 100%;
+  }
 `
 
 const Label = styled.span`
@@ -162,11 +183,13 @@ class Demo extends React.Component {
                   staggerDelayBy={100}
                   duration={300}
                   leaveAnimation="none">
+          <span className="wayfinder">1st paint</span>
           { store.demo.order.map((e, i) => (
             <Square key={e.key} {...e}>
               {e.text && <Label>{e.text}</Label>}
             </Square>
           )) }
+          <span className="wayfinder">Last paint</span>
         </FlipMove>
         <span>Something not look
           right? <Link href={report(this.props.num)} target="_blank">Open an issue</Link>.

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,7 +8,7 @@ body {
 
 .Container {
   font-size: 1.8rem;
-  min-width: 10em;
+  min-width: 100%;
   min-height: 10em;
   z-index: 0;
   position: relative;
@@ -21,7 +21,7 @@ body {
 
 .Box {
   border: 1px dashed black;
-  width: 10em;
+  width: 100%;
   height: 10em;
   padding: 1em;
   background: repeating-linear-gradient(45deg, #ccc 0, #ccc 1em, transparent 1em, transparent 2em);


### PR DESCRIPTION
Had a play with the spacing on the demos, and swapped the order on mobile so that the it more accurately represents the top to bottom of the layers.

The CSS is a little wonky, and could be 100% more `styled-component`-esque, but I think visually it's easier to understand. There may be a way to do it without `@media`, too.

If you dig it I can sort out the CSS and make it fancier.

Screens!

<img width="1189" alt="screen shot 2017-03-06 at 4 53 32 pm" src="https://cloud.githubusercontent.com/assets/449385/23622274/ea8a97c2-0295-11e7-9f51-1edbbfe9fd6c.png">

<img width="491" alt="screen shot 2017-03-06 at 4 53 40 pm" src="https://cloud.githubusercontent.com/assets/449385/23622277/eda73a32-0295-11e7-8d56-c8d8de199ced.png">
